### PR TITLE
PoC of plugin actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ htmlcov/
 .project
 .pycharm_helpers/
 .pydevproject
+.vscode
 
 # The Silver Searcher
 .agignore

--- a/edx_django_utils/plugins/__init__.py
+++ b/edx_django_utils/plugins/__init__.py
@@ -5,6 +5,7 @@ See README.rst for details.
 """
 
 from .constants import PluginContexts, PluginSettings, PluginSignals, PluginURLs
+from .plugin_actions import do_plugin_action
 from .plugin_apps import get_plugin_apps
 from .plugin_contexts import get_plugins_view_context
 from .plugin_manager import PluginError, PluginManager

--- a/edx_django_utils/plugins/constants.py
+++ b/edx_django_utils/plugins/constants.py
@@ -67,3 +67,13 @@ class PluginContexts():
     """
 
     CONFIG = "view_context_config"
+
+class PluginActions():
+    """
+    The PluginActions enum defines dictionary field names (and defaults)
+    that can be specified by a Plugin App in order to configure the
+    hooks that want be used.
+    """
+
+    CONFIG = "actions_config"
+

--- a/edx_django_utils/plugins/plugin_actions.py
+++ b/edx_django_utils/plugins/plugin_actions.py
@@ -1,0 +1,84 @@
+"""
+Various functions to run plugin acctions
+
+Please remember to expose any new public methods in the `__init__.py` file.
+"""
+import functools
+from importlib import import_module
+from logging import getLogger
+
+from . import constants, registry
+
+log = getLogger(__name__)
+
+
+def do_plugin_action(project_type, namespace, *args, **kwargs):
+    """
+    Will check if any plugin apps have that namespace in their actions_config, and if so will call their
+    selected function..
+
+    Params:
+        project_type: a string that determines which project (lms or studio) the view is being called in. See the
+            ProjectType enum in plugins/constants.py for valid options
+        namespace: a string that determines which is the namespace of this action.
+    """
+
+    action_functions = _get_cached_action_functions_for_namespace(project_type, namepsace)
+
+    for (action_function, plugin_name) in action_functions:
+        try:
+            action_function(*args, **kwargs)
+        except Exception as exc:  # pylint: disable=broad-except
+            # We're catching this because we don't want the core to blow up when a
+            # plugin is broken. This exception will probably need some sort of
+            # monitoring hooked up to it to make sure that these errors don't go
+            # unseen.
+            log.exception("Failed to call plugin <%s> action function. Error: %s", plugin_name, exc)
+            continue
+
+
+@functools.lru_cache(maxsize=None)
+def _get_cached_action_functions_for_namespace(project_type, namespace):
+    """
+    Returns a list of tuples where the first item is the action function
+    and the second item is the name of the plugin it's being called from.
+
+    NOTE: These will be functions will be cached (in RAM not memcache) on this unique
+    combination. If we enable many new views to use this system, we may notice an
+    increase in memory usage as the entirety of these functions will be held in memory.
+    """
+    action_functions = []
+    for app_config in registry.get_plugin_app_configs(project_type):
+        action_function_path = _get_action_function_path(
+            app_config, project_type, namespace
+        )
+        if action_function_path:
+            module_path, _, name = action_function_path.rpartition(".")
+            try:
+                module = import_module(module_path)
+            except ImportError:
+                log.exception(
+                    "Failed to import %s plugin when creating %s action",
+                    module_path,
+                    namespace,
+                )
+                continue
+            action_function = getattr(module, name, None)
+            if action_function:
+                plugin_name, _, _ = module_path.partition(".")
+                action_functions.append((action_function, plugin_name))
+            else:
+                log.warning(
+                    "Failed to retrieve %s function from %s plugin when creating %s action",
+                    name,
+                    module_path,
+                    namespace,
+                )
+    return action_function
+
+
+def _get_action_function_path(app_config, project_type, namespace):
+    plugin_config = getattr(app_config, constants.PLUGIN_APP_CLASS_ATTRIBUTE_NAME, {})
+    actions_config = plugin_config.get(constants.PluginActions.CONFIG, {})
+    project_type_settings = action_config.get(project_type, {})
+    return project_type_settings.get(namespace)

--- a/edx_django_utils/plugins/plugin_actions.py
+++ b/edx_django_utils/plugins/plugin_actions.py
@@ -23,7 +23,7 @@ def do_plugin_action(project_type, namespace, *args, **kwargs):
         namespace: a string that determines which is the namespace of this action.
     """
 
-    action_functions = _get_cached_action_functions_for_namespace(project_type, namepsace)
+    action_functions = _get_cached_action_functions_for_namespace(project_type, namespace)
 
     for (action_function, plugin_name) in action_functions:
         try:
@@ -74,11 +74,11 @@ def _get_cached_action_functions_for_namespace(project_type, namespace):
                     module_path,
                     namespace,
                 )
-    return action_function
+    return action_functions
 
 
 def _get_action_function_path(app_config, project_type, namespace):
     plugin_config = getattr(app_config, constants.PLUGIN_APP_CLASS_ATTRIBUTE_NAME, {})
     actions_config = plugin_config.get(constants.PluginActions.CONFIG, {})
-    project_type_settings = action_config.get(project_type, {})
+    project_type_settings = actions_config.get(project_type, {})
     return project_type_settings.get(namespace)


### PR DESCRIPTION
**Description:**

In this PR are we are adding the tools and functions to run the action hooks using the plugin infrastructure. Each plugin should add in their configurations the actions_config specifying the function that should be called for each trigger.

For instance:

```python
actions_config: {
      "preenrollment": "myplugin.actions.check_user_has_access_to_institution"
}
```


**Merge deadline:**

None



****Author concerns:**

In one hand, I like the idea of using the plugin infrastructure. This solution is pretty similar to the context_view functionality already provided in the plugins infrastructure.

On the other hand, I don't like the fact that is not clear to me if with this approach the functions will be called always in the same order and that we cannot override that order